### PR TITLE
change: KeepZoomAfterSeach

### DIFF
--- a/components/AutocompleteWebComponent.tsx
+++ b/components/AutocompleteWebComponent.tsx
@@ -33,9 +33,9 @@ export const AutocompleteWebComponent = ({onPlaceSelect}: Props) => {
         });
 
         // If the place has a viewport (area boundaries), adjust the map to show it
-        if (place?.viewport) {
-          map?.fitBounds(place.viewport);
-        }
+      if (place?.location) {
+        map?.setCenter(place.location);
+      }
 
         onPlaceSelect(place);
       } catch (error) {


### PR DESCRIPTION
・目的  
- 検索後も既存の zoom を維持したい  

***  

・修正箇所  
- fitBounds() → setCenter(location) に変更  
  - fitBounds は zoom を自動調整してしまう  
  - setCenter は zoom に影響せず、中心のみ変更  

***  

・結果  
- 検索後も zoom が変更されず、使いやすさが向上  
- 意図しない拡大表示を防止できるようになった  

***  

#### 差異  

| ![before](https://imgur.com/4ho6y6V.gif) | ![after](https://imgur.com/fFtO8G6.gif) |  
|:-----------:|:------------:|  
| 修正前 | 修正後 |