### PR TITLE
change: AutoCompleteResultToJP

### DIFF
--- a/components/AutocompleteWebComponent.tsx
+++ b/components/AutocompleteWebComponent.tsx
@@ -82,6 +82,7 @@ export const AutocompleteWebComponent = ({onPlaceSelect}: Props) => {
         - ongmp-placeselect: Deprecated but still used in beta channel
       */}
       <gmp-place-autocomplete
+        requested-language="ja"
         ongmp-select={handleGmpSelect as any}
         ongmp-placeselect={handleGmpPlaceSelect as any}
         aria-label="Search for a location"


### PR DESCRIPTION
・目的  
- AutoCompleteで取得される候補や施設情報を日本語で表示したい

***

・修正箇所  
- gmp-place-autocomplete に requested-language="ja" を追加  
  - AutoCompleteの候補が日本語で表示されるように設定  

***

・結果  
- AutoCompleteの候補やリストの施設名・住所などが日本語で表示されるようになった

***

#### 差異  

##### Marker  
| ![](https://i.gyazo.com/b2bf23ea91bbc42c5a8ebc530f2aee1c.png) | ![](https://i.gyazo.com/57009b56b5eda9094bf89b93350cce9e.png) |  
|:-----------:|:------------:|  
| 修正前 | 修正後 |